### PR TITLE
Corrected formatting for consistency angular.js

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -251,7 +251,7 @@ function forEach(obj, iterator, context) {
     if (isFunction(obj)) {
       for (key in obj) {
         // Need to check if hasOwnProperty exists,
-        // as on IE8 the result of querySelectorAll is an object without a hasOwnProperty function
+        // as on IE8 the result of querySelectorAll is an object without a hasOwnProperty function.
         if (key != 'prototype' && key != 'length' && key != 'name' && (!obj.hasOwnProperty || obj.hasOwnProperty(key))) {
           iterator.call(context, obj[key], key, obj);
         }
@@ -666,7 +666,7 @@ var escapeForRegexp = function(s) {
 function isElement(node) {
   return !!(node &&
     (node.nodeName  // we are a direct element
-    || (node.prop && node.attr && node.find)));  // we have an on and find method part of jQuery API
+    || (node.prop && node.attr && node.find)));  // We have an on and find method part of jQuery API.
 }
 
 /**
@@ -1047,7 +1047,7 @@ function bind(self, fn) {
             : fn.call(self);
         };
   } else {
-    // in IE, native methods are not functions so they cannot be bound (note: they don't need to be)
+    // In IE, native methods are not functions so they cannot be bound (note: they don't need to be).
     return fn;
   }
 }
@@ -1170,7 +1170,7 @@ function tryDecodeURIComponent(value) {
   try {
     return decodeURIComponent(value);
   } catch (e) {
-    // Ignore any invalid uri component
+    // Ignore any invalid uri component.
   }
 }
 
@@ -1402,7 +1402,7 @@ function angularInit(element, bootstrap) {
       module,
       config = {};
 
-  // The element `element` has priority over any other element
+  // The element `element` has priority over any other element.
   forEach(ngAttrPrefixes, function(prefix) {
     var name = prefix + 'app';
 
@@ -1487,7 +1487,7 @@ function bootstrap(element, modules, config) {
 
     if (element.injector()) {
       var tag = (element[0] === document) ? 'document' : startingTag(element);
-      //Encode angle brackets to prevent input from being sanitized to empty string #8683
+      // Encode angle brackets to prevent input from being sanitized to empty string #8683.
       throw ngMinErr(
           'btstrpd',
           "App Already Bootstrapped with this Element '{0}'",


### PR DESCRIPTION
Corrected formatting errors on lines 254, 669, 1050, 1173, 1405, and 1490 by adding periods at the end of single line comments that were missing them in order to be consistent with the formatting found in the file.

Capitalized the first letter in the first word of the comments on lines 669 and 1050, to be consistent with the formatting of the rest of the file.

Added a space after "//" in the comment on line 1490 to be consistent with the formatting of the rest of the file.
